### PR TITLE
Update to support 2021 features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@
 plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
-    id "edu.wpi.first.GradleRIO" version "2020.3.2"
+    id "edu.wpi.first.GradleRIO" version "2021.1.2"
 }
 
 sourceSets {

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,81 +1,69 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix",
-    "version": "5.18.2",
+    "version": "5.19.4",
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
-        "http://devsite.ctr-electronics.com/maven/release/"
+        "https://devsite.ctr-electronics.com/maven/release/"
     ],
-    "jsonUrl": "http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
+    "jsonUrl": "https://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix/Phoenix-latest.json",
     "javaDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.18.2"
+            "version": "5.19.4"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.18.2"
+            "version": "5.19.4"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
-                "linuxathena",
-                "windowsx86-64",
-                "linuxx86-64"
+                "linuxathena"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "diagnostics",
-            "version": "5.18.2",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
-                "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "canutils",
-            "version": "5.18.2",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "platform-stub",
-            "version": "5.18.2",
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
-            ]
-        },
-        {
-            "groupId": "com.ctre.phoenix",
-            "artifactId": "core",
-            "version": "5.18.2",
-            "isJar": false,
-            "skipInvalidPlatforms": true,
-            "validPlatforms": [
-                "linuxathena",
-                "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         }
     ],
@@ -83,7 +71,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -91,13 +79,14 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -105,27 +94,40 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
-                "linuxathena",
+                "linuxathena"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "cci-sim",
+            "version": "5.19.4",
+            "libName": "CTRE_PhoenixCCISim",
+            "headerClassifier": "headers",
+            "sharedLibrary": false,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "diagnostics",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixDiagnostics",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -133,39 +135,42 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "canutils",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCanutils",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
-            "artifactId": "platform-stub",
-            "version": "5.18.2",
+            "artifactId": "platform-sim",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixPlatform",
             "headerClassifier": "headers",
             "sharedLibrary": false,
             "skipInvalidPlatforms": true,
             "binaryPlatforms": [
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
             ]
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "core",
-            "version": "5.18.2",
+            "version": "5.19.4",
             "libName": "CTRE_PhoenixCore",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -173,7 +178,36 @@
             "binaryPlatforms": [
                 "linuxathena",
                 "windowsx86-64",
-                "linuxx86-64"
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simTalonSRX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimTalonSRX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
+            ]
+        },
+        {
+            "groupId": "com.ctre.phoenix.sim",
+            "artifactId": "simVictorSPX",
+            "version": "5.19.4",
+            "libName": "CTRE_SimVictorSPX",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxx86-64",
+                "osxx86-64"
             ]
         }
     ]


### PR DESCRIPTION
2021 has brought full simulation support to WPILib and CTRE libraries, so the vendordeps and WPILib versions have to be updated.